### PR TITLE
MdVNE: Fixes an incorrect look-up structure in case a model gets loaded via an XMI file

### DIFF
--- a/network.model/src/facade/ModelFacade.java
+++ b/network.model/src/facade/ModelFacade.java
@@ -318,7 +318,7 @@ public class ModelFacade {
 	 * @param id ID to return node object for.
 	 * @return Node object for given ID.
 	 */
-	private Node getNodeById(final String id) {
+	public Node getNodeById(final String id) {
 		checkStringValid(id);
 
 		List<Network> nets = getRoot().getNetworks();

--- a/network.model/src/facade/ModelFacade.java
+++ b/network.model/src/facade/ModelFacade.java
@@ -1092,6 +1092,13 @@ public class ModelFacade {
 				final SubstrateNetwork sNet = (SubstrateNetwork) n;
 				for (final SubstratePath p : sNet.getPaths()) {
 					this.paths.put(p.getName(), p);
+
+					// Add path to lookup map
+					final SubstrateNode source = p.getSource();
+					if (!pathSourceMap.containsKey(source)) {
+						pathSourceMap.put(source, new HashSet<SubstratePath>());
+					}
+					pathSourceMap.get(source).add(p);
 				}
 			}
 		}


### PR DESCRIPTION
This PR also sets the visibility of the method `getNodeById(...)` to `public`.