### PR TITLE
Removes moflon core utilities dependency from `network.model`

### DIFF
--- a/network.model/META-INF/MANIFEST.MF
+++ b/network.model/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Automatic-Module-Name: network.model
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,
  org.junit,
- org.moflon.core.utilities,
  org.emoflon.smartemf,
  gips.examples.dependencies
 Export-Package: facade,


### PR DESCRIPTION
Closes https://github.com/Echtzeitsysteme/iflye/issues/99.