### PR TITLE
lectureStudio model B impl: changes GenParameter from record to class

### DIFF
--- a/LectureStudioModelB/src/lsmodel/generator/GenParameter.java
+++ b/LectureStudioModelB/src/lsmodel/generator/GenParameter.java
@@ -17,7 +17,10 @@ import java.util.Random;
  *  	2. mean
  *  	3. deviation
  */
-public record GenParameter(GenDistribution dist, double[] parameters) {
+public class GenParameter {
+	public final GenDistribution dist;
+	public final double[] parameters;
+
 	public GenParameter(GenDistribution dist, double... parameters) {
 		this.dist = dist;
 		this.parameters = parameters;


### PR DESCRIPTION
This resolves a compilation error of a vararg for newer Java versions/the latest Eclipse version.