### PR TITLE
Resolves (case insensitive) naming conflicts in a few projects

### DIFF
--- a/ihtcgipssolution/src/ihtcgipssolution/Model.gipsl
+++ b/ihtcgipssolution/src/ihtcgipssolution/Model.gipsl
@@ -314,7 +314,7 @@ pattern nurseShiftRoomMaxLoad {
 	r: Room
 }
 
-pattern nurseShiftMaxLoad {
+pattern findNurseShiftMaxLoad {
 	h: Hospital {
 		-nurses -> n
 		-shifts -> s
@@ -424,7 +424,7 @@ mapping nurseShiftRoomLoad to nurseShiftRoomMaxLoad {
 // Mapping that holds the `overload` of nurse `n` in shift `s`
 // `overload` = 0 if the cumulative load of `n` does not exceed the maximum workload
 // `overload` = cumulative_load - n_maximum_workload otherwise
-mapping nurseShiftOverload to nurseShiftMaxLoad {
+mapping nurseShiftOverload to findNurseShiftMaxLoad {
 	var overload : EInt
 };
 

--- a/org.emoflon.gips.gipsl.examples.lsp2p/src/org/emoflon/gips/gipsl/examples/lsp2p/batch/lsp2p_batch.gipsl
+++ b/org.emoflon.gips.gipsl.examples.lsp2p/src/org/emoflon/gips/gipsl/examples/lsp2p/batch/lsp2p_batch.gipsl
@@ -48,7 +48,7 @@ rule addClient(hasRoot: EInt, bw: EDouble, tt: EDouble) {
 }
 when clientIsWaiting
 
-rule node {
+rule assignNode {
 	node: Node {
 		++ -configuration -> cfg
 	}
@@ -64,7 +64,7 @@ mapping relay2Client to addClient {
 	var transferTime : EDouble bind tt // Gibt die Zeit an, die es braucht um das File bis zum Client zu transportieren.
 };
 
-mapping node2Cfg to node;
+mapping node2Cfg to assignNode;
 
 /*	Setzt die Konfluenzbedingung für die Einbettung: Es darf maximal und es muss mindestens eine Mappingvariable ausgewählt werden.	
  */
@@ -99,19 +99,19 @@ constraint with Node {
 	mappings.node2Cfg->filter(element.nodes.node == context)->sum(element.value) <= 1
 }
 
-constraint with node {
+constraint with assignNode {
 	mappings.relay2Client->filter(element.nodes.relay == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) >= 1 =>
 	[mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) <= 1 &
 		mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) >= 1]
 }
 
-constraint with node {
+constraint with assignNode {
 	mappings.relay2Client->filter(element.nodes.relay == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) <= 0 =>
 	[mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) <= 0 &
 		mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) >= 0]
 }
 
-constraint with node {
+constraint with assignNode {
 	mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) >= 1 =>
 	[mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.nodes.cfg.clients) <=
 		mappings.relay2Client->filter(element.nodes.relay == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) &
@@ -119,7 +119,7 @@ constraint with node {
 		mappings.relay2Client->filter(element.nodes.relay == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value)]
 }
 
-constraint with node {
+constraint with assignNode {
 	mappings.node2Cfg->filter(element.nodes.node == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) <= 0 =>
 	mappings.relay2Client->filter(element.nodes.relay == context.nodes.node & element.nodes.cfg == context.nodes.cfg)->sum(element.value) <= 0
 }

--- a/org.emoflon.gips.gipsl.examples.sdr.extended/src/org/emoflon/gips/gipsl/examples/extended/sdr/Model.gipsl
+++ b/org.emoflon.gips.gipsl.examples.sdr.extended/src/org/emoflon/gips/gipsl/examples/extended/sdr/Model.gipsl
@@ -87,7 +87,7 @@ rule flow2thread {
 	thread: Thread
 }
 
-rule thread(complexity: EDouble, diff: EDouble, absDiff: EDouble) {
+rule updateThread(complexity: EDouble, diff: EDouble, absDiff: EDouble) {
 	cpu: CPU {
 		-cores -> core
 	}
@@ -113,7 +113,7 @@ mapping f2i to flow2intercom;
 
 mapping f2t to flow2thread;
 
-mapping usedThread to thread {
+mapping usedThread to updateThread {
 	var complexity : EDouble bind complexity
 	var diff : EDouble bind diff
 	var absDiff : EDouble bind absDiff

--- a/org.emoflon.gips.gipsl.examples.sdr/src/org/emoflon/gips/gipsl/examples/sdr/Model.gipsl
+++ b/org.emoflon.gips.gipsl.examples.sdr/src/org/emoflon/gips/gipsl/examples/sdr/Model.gipsl
@@ -85,7 +85,7 @@ rule flow2thread {
 	thread: Thread
 }
 
-pattern thread {
+pattern findThread {
 	thread: Thread
 }
 
@@ -100,7 +100,7 @@ mapping f2i to flow2intercom;
 mapping f2t to flow2thread;
 
 // Utility mapping that must be 1 if the corresponding thread will be used, 0 otherwise
-mapping usedThread to thread;
+mapping usedThread to findThread;
 
 //
 // General remarks for the two following constraints:


### PR DESCRIPTION
After the introduction of our more aggressive name-duplicate checking (see https://github.com/Echtzeitsysteme/gips/pull/356), the changes in this PR are necessary to make the projects in question compile again.

This PR addresses my comment [here](https://github.com/Echtzeitsysteme/gips-tests/pull/138#issuecomment-4076264421).

Blocked by https://github.com/Echtzeitsysteme/gips/pull/356.